### PR TITLE
Fix incorrect command name in getting started text

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -181,7 +181,7 @@ class Render {
     }
 
     if (pending + complete + notes === 0) {
-      log({prefix: '\n ', message: 'Type `taskbook --help` to get started!', suffix: yellow('★')});
+      log({prefix: '\n ', message: 'Type `tb --help` to get started!', suffix: yellow('★')});
     }
 
     log({prefix: '\n ', message: grey(`${percent} of all tasks complete.`)});


### PR DESCRIPTION
Thanks for this amazing tool 😄 I have been wanting one like this for long.

I installed this and noticed that when I ran for the first time, it displayed,

```
Type `taskbook --help` to get started!
```

when it should have been 
```
Type `tb --help` to get started!
```