### PR TITLE
Fixed '-h' and '-v' parameters that not worked

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -8,6 +8,10 @@ const taskbook = require('.');
 
 const cli = meow(help, {
   flags: {
+    help: {
+      type: 'boolean',
+      alias: 'h'
+    },
     archive: {
       type: 'boolean',
       alias: 'a'

--- a/cli.js
+++ b/cli.js
@@ -12,6 +12,10 @@ const cli = meow(help, {
       type: 'boolean',
       alias: 'h'
     },
+    version: {
+      type: 'boolean',
+      alias: 'v'
+    },
     archive: {
       type: 'boolean',
       alias: 'a'


### PR DESCRIPTION
In 'help' written that we can use '-h' instead of '--help' but it is **not working**
In 'help' written that we can use '-v' instead of '--version' but it is **not working**
Now it is works :)

![image](https://user-images.githubusercontent.com/13422799/43509743-2387cb9c-957c-11e8-9feb-e6e7f5ae9a5e.png)

![image](https://user-images.githubusercontent.com/13422799/43510702-25d96f6a-957f-11e8-9b78-face677b45a0.png)


Fix issue #13 and #7 