### PR TITLE
chore: remove Node.js 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - 10
-  - 9
   - 8
   - 6
 before_install:


### PR DESCRIPTION
Node.js 6, 8 and 10 are LTS and stable releases.
Odd releases like Node.js 9 are intermediate and shortliving releases.

Node.js 9 reached its EOL, see https://github.com/nodejs/Release