### PR TITLE
Fix welcome message

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -181,7 +181,7 @@ class Render {
     }
 
     if (pending + complete + notes === 0) {
-      log({prefix: '\n ', message: 'Type `taskbook --help` to get started!', suffix: yellow('★')});
+      log({prefix: '\n ', message: 'Type `tb --help` to get started!', suffix: yellow('★')});
     }
 
     log({prefix: '\n ', message: grey(`${percent} of all tasks complete.`)});


### PR DESCRIPTION
Welcome message used to instruct users to run `taskbook --help` to get started. This command doesn't do anything so this PR changes it to say `tb --help`.

<!--

Thank you for taking the time to contribute to Taskbook!

For more info on how to contribute to the project, please read the [contributing guidelines](https://github.com/klauscfhq/taskbook/blob/master/contributing.md).

We are always excited about pull requests!

If the pull request fixes any open issues, reference the corresponding issues, e.g: `Fixes #321`.

Including test results, screenshots/gifs if applicable/possible, alongside new features and bug fixes is something that we strongly encourage.

Thank you so much for all of the time and effort you put in the project!

-->
