### PR TITLE
Use .config directory for taskbook.json

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -9,7 +9,7 @@ const {default: defaultConfig} = pkg.configuration;
 
 class Config {
   constructor() {
-    this._configFile = join(os.homedir(), '.taskbook.json');
+    this._configFile = join(os.homedir(), '.config/taskbook/taskbook.json');
 
     this._ensureConfigFile();
   }


### PR DESCRIPTION
If it can't be specified dynamically, it is nice to have config files located in the ~/.config directory. This follows the standard used by many other programs and prevents the homedir from getting unreasonably cluttered with configs. 

Docs still need to be updated if you decide to merge this.