### PR TITLE
Increase required version of node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
   - 10
   - 9
   - 8
-  - 6
+  - 7
 before_install:
   - npm install --global npm@6.2.0
   - npm --version

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "tb": "cli.js"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=7"
   },
   "files": [
     "lib",


### PR DESCRIPTION
You're using `String.prototype.padEnd` in various places and that is not supported at all in NodeJS v6. It needs to be at least v7 to use that function (with a flag).

<!--

Thank you for taking the time to contribute to Taskbook!

For more info on how to contribute to the project, please read the [contributing guidelines](https://github.com/klauscfhq/taskbook/blob/master/contributing.md).

We are always excited about pull requests!

If the pull request fixes any open issues, reference the corresponding issues, e.g: `Fixes #321`.

Including test results, screenshots/gifs if applicable/possible, alongside new features and bug fixes is something that we strongly encourage.

Thank you so much for all of the time and effort you put in the project!

-->
