### PR TITLE
fix: -e flag in taskbook help description

### DIFF
--- a/lib/help.js
+++ b/lib/help.js
@@ -14,7 +14,7 @@ module.exports = `
       --star, -s         Star/unstar item
       --list, -l         List items by attributes
       --find, -f         Search for items
-      --edit, -t         Edit item description
+      --edit, -e         Edit item description
       --move, -m         Move item between boards
       --priority, -p     Update priority of task
       --archive, -a      Display archived items


### PR DESCRIPTION
Fixed `-e` flag in help description