### PR TITLE
feat: Added "--after" option

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -59,7 +59,10 @@ const cli = meow(help, {
     move: {
       type: 'boolean',
       alias: 'm'
-    }
+    },
+    after: {
+      type: 'string',
+    },
   }
 });
 

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ const taskbookCLI = (input, flags) => {
   }
 
   if (flags.list) {
-    taskbook.listByAttributes(input);
+    taskbook.listByAttributes(input, flags.after);
     return taskbook.displayStats();
   }
 
@@ -55,6 +55,11 @@ const taskbookCLI = (input, flags) => {
 
   if (flags.move) {
     return taskbook.moveBoards(input);
+  }
+
+  if (flags.after) {
+    taskbook.listByAttributes([], flags.after);
+    return taskbook.displayStats();
   }
 
   taskbook.displayByBoard();

--- a/lib/taskbook.js
+++ b/lib/taskbook.js
@@ -1,9 +1,12 @@
 #!/usr/bin/env node
 'use strict';
+const moment = require('moment')
 const Task = require('./task');
 const Note = require('./note');
 const Storage = require('./storage');
 const render = require('./render');
+
+const DATE_FORMATTER = 'YYYYMMDD'
 
 class Taskbook {
   constructor() {
@@ -235,6 +238,15 @@ class Taskbook {
     return data;
   }
 
+  _filterAfterDate(date = moment().format(DATE_FORMATTER), data = this._data) {
+    Object.entries(data).forEach(([id, item]) => {
+      if (!moment(item._timestamp).isAfter(moment(date)))
+        delete data[id]
+    })
+
+    return data;
+  }
+
   _groupByBoard(data = this._data, boards = this._getBoards()) {
     const grouped = {};
 
@@ -395,7 +407,7 @@ class Taskbook {
     render.displayByBoard(this._groupByBoard(result));
   }
 
-  listByAttributes(terms) {
+  listByAttributes(terms, afterDate) {
     let [boards, attributes] = [[], []];
     const storedBoards = this._getBoards();
 
@@ -408,7 +420,12 @@ class Taskbook {
 
     [boards, attributes] = [boards, attributes].map(x => this._removeDuplicates(x));
 
-    const data = this._filterByAttributes(attributes);
+    let data = this._filterByAttributes(attributes);
+
+    if (afterDate) {
+      data = this._filterAfterDate(afterDate, data)
+    }
+
     render.displayByBoard(this._groupByBoard(data, boards));
   }
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "chalk": "^2.4.1",
     "meow": "^5.0.0",
+    "moment": "^2.22.2",
     "signale": "^1.2.1",
     "update-notifier": "^2.5.0"
   },


### PR DESCRIPTION
<!--

Thank you for taking the time to contribute to Taskbook!

For more info on how to contribute to the project, please read the [contributing guidelines](https://github.com/klauscfhq/taskbook/blob/master/contributing.md).

We are always excited about pull requests!

If the pull request fixes any open issues, reference the corresponding issues, e.g: `Fixes #321`.

Including test results, screenshots/gifs if applicable/possible, alongside new features and bug fixes is something that we strongly encourage.

Thank you so much for all of the time and effort you put in the project!

-->

We can use `--after` to filter the task data by date. like this: 

```
tb --list done --after 20180804
```

or

```
tb --after 20180804
```