### PR TITLE
Fixed some unicode issues on some terminals.

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -2,6 +2,7 @@
 const chalk = require('chalk');
 const signale = require('signale');
 const config = require('./config');
+const hasUnicode = require('has-unicode');
 
 signale.config({displayLabel: false});
 
@@ -9,6 +10,8 @@ const {error, log, note, pending, success} = signale;
 const {blue, green, grey, magenta, red, underline, yellow} = chalk;
 
 const priorities = {2: 'yellow', 3: 'red'};
+
+const ch_star = hasUnicode() ? '★' : '*';
 
 class Render {
   get _configuration() {
@@ -52,7 +55,7 @@ class Render {
   }
 
   _getStar(item) {
-    return item.isStarred ? yellow('★') : '';
+    return item.isStarred ? yellow(ch_star) : '';
   }
 
   _buildTitle(key, items) {
@@ -177,11 +180,11 @@ class Render {
     ];
 
     if (complete !== 0 && pending === 0 && notes === 0) {
-      log({prefix: '\n ', message: 'All done!', suffix: yellow('★')});
+      log({prefix: '\n ', message: 'All done!', suffix: hasUnicode() ? yellow(ch_star) : yellow("^_^")});
     }
 
     if (pending + complete + notes === 0) {
-      log({prefix: '\n ', message: 'Type `tb --help` to get started!', suffix: yellow('★')});
+      log({prefix: '\n ', message: 'Type `tb --help` to get started!', suffix: yellow(ch_star)});
     }
 
     log({prefix: '\n ', message: grey(`${percent} of all tasks complete.`)});

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "taskbook",
   "productName": "Taskbook",
   "version": "0.1.1",
-  "description": "📓 Tasks, boards & notes for the command-line habitat",
+  "description": "Tasks, boards & notes for the command-line habitat",
   "repository": "klauscfhq/taskbook",
   "license": "MIT",
   "author": {
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "chalk": "^2.4.1",
+    "has-unicode": "^2.0.1",
     "meow": "^5.0.0",
     "signale": "^1.2.1",
     "update-notifier": "^2.5.0"


### PR DESCRIPTION
Closes #36.

Notes:
* This removes unicode from the description in package.json, since it is displayed by meow in the cli when a user runs `tb -h`. If this turns out to be controversial it is an easy revert.
* There are a few unicode characters included by signale that we don't have control over.