### PR TITLE
Add Snap Package Installation Guide on Readme. Fixes #38.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,9 +60,20 @@ View highlights in a [taskbook board](https://raw.githubusercontent.com/klauscfh
 
 ## Install
 
+### NPM
+
 ```bash
 npm install --global taskbook
 ```
+
+### Snapcraft
+
+```bash
+snap install taskbook
+snap alias taskbook tb # set alias
+```
+
+**Note:** Due to the snap's strictly confined nature, both the storage & configuration files will be saved under the [`$SNAP_USER_DATA`](https://docs.snapcraft.io/reference/env) environment variable instead of the generic `$HOME` one.
 
 ## Usage
 


### PR DESCRIPTION
### Preview

Taskbook is now available as an official snap, dedicated to Linux systems, on the [Snap store](https://snapcraft.io/taskbook).
This PR includes a minor installation guide for the taskbook snapcraft package.

### Changes

- Added snap package installation guide on readme. https://github.com/klauscfhq/taskbook/commit/94b4a8e14f6e817297609bdd443ddd0ca5d2c7bc

### Resolved Issues

- Resolves issue #38.