### PR TITLE
Render 'note' if only one note exists

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -173,7 +173,7 @@ class Render {
     const status = [
       `${green(complete)} ${grey('done')}`,
       `${magenta(pending)} ${grey('pending')}`,
-      `${blue(notes)} ${grey('notes')}`
+      `${blue(notes)} ${grey(notes === 1 ? 'note' : 'notes')}`
     ];
 
     if (complete !== 0 && pending === 0 && notes === 0) {


### PR DESCRIPTION
First of all, thanks for this project. I plan on contributing more meaningfully in the future but this is just a quick one off I found.

If you only have one note in the system and you have the bottom display configured to render, you see a minor typo:
![screen shot 2018-10-24 at 9 24 29 am](https://user-images.githubusercontent.com/35499926/47433605-c79b0580-d76e-11e8-9634-d06d02f2c0b4.png)

With this fix, the typo is fixed:
![screen shot 2018-10-24 at 9 24 13 am](https://user-images.githubusercontent.com/35499926/47433624-d08bd700-d76e-11e8-85ab-109a5b3b1825.png)

All other variations are also (still) correct:
![screen shot 2018-10-24 at 9 27 01 am](https://user-images.githubusercontent.com/35499926/47433748-029d3900-d76f-11e8-95d0-51b5091ad5be.png)

![screen shot 2018-10-24 at 9 27 35 am](https://user-images.githubusercontent.com/35499926/47433779-121c8200-d76f-11e8-9d03-7b911a69b862.png)


